### PR TITLE
Add pr build and lint workflow

### DIFF
--- a/.github/workflows/CODEOWNERS
+++ b/.github/workflows/CODEOWNERS
@@ -1,0 +1,2 @@
+# These are the default owners for the whole repo. They will be requested for review wehen someone opens a pull request.
+* @f2face

--- a/.github/workflows/pr-lint-build.yml
+++ b/.github/workflows/pr-lint-build.yml
@@ -1,0 +1,38 @@
+name: Lint and Build
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: pnpm/action-setup@v2
+        with:
+          version: latest
+      - uses: actions/setup-node@v3
+        with:
+          node-version: "18.x"
+          cache: "pnpm"
+      - name: Install dependencies
+        run: pnpm install
+      - name: Run lint
+        run: pnpm lint
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: pnpm/action-setup@v2
+        with:
+          version: latest
+      - uses: actions/setup-node@v3
+        with:
+          node-version: "18.x"
+          cache: "pnpm"
+      - name: Install dependencies
+        run: pnpm install
+      - name: Run build
+        run: pnpm build


### PR DESCRIPTION
Adds a build and lint workflow that should be used on pull requests to verify that the code builds and follows the format as a form of pre review.

Requires #6 to be merged first!