### PR TITLE
Add config overrides in R2

### DIFF
--- a/src/Bucket.ts
+++ b/src/Bucket.ts
@@ -10,6 +10,7 @@ import {
     ListObjectsCommand,
     PutObjectCommand,
     type S3Client as R2,
+    S3ClientConfig
 } from '@aws-sdk/client-s3';
 import { Upload, type Progress } from '@aws-sdk/lib-storage';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
@@ -20,7 +21,7 @@ import type { CORSPolicy, HeadObjectResponse, ObjectListResponse, UploadFileResp
 
 export class Bucket {
     private r2: R2;
-    private endpoint: string;
+    private endpoint: S3ClientConfig['endpoint'];
     private bucketPublicUrls: string[] = [];
 
     /**
@@ -41,10 +42,10 @@ export class Bucket {
      * @param bucketName Name of the bucket.
      * @param endpoint Cloudflare R2 base endpoint.
      */
-    constructor(r2: R2, bucketName: string, endpoint: string) {
+    constructor(r2: R2, bucketName: string, endpoint: S3ClientConfig['endpoint']) {
         this.r2 = r2;
         this.name = bucketName;
-        this.endpoint = new URL(endpoint).origin;
+        this.endpoint = endpoint;
         this.uri = `${this.endpoint}/${this.name}`;
     }
 

--- a/src/R2.ts
+++ b/src/R2.ts
@@ -1,4 +1,4 @@
-import { CreateBucketCommand, DeleteBucketCommand, ListBucketsCommand, S3Client } from '@aws-sdk/client-s3';
+import { CreateBucketCommand, DeleteBucketCommand, ListBucketsCommand, S3Client, S3ClientConfig } from '@aws-sdk/client-s3';
 import { Bucket } from './Bucket';
 import type { BucketList, CORSPolicy, CloudflareR2Config } from './types';
 
@@ -7,10 +7,12 @@ export class R2 {
     private r2: S3Client;
     public endpoint: string;
 
-    constructor(config: CloudflareR2Config) {
+    constructor(config: CloudflareR2Config, overrides?: S3ClientConfig) {
         this.config = config;
 
-        if (this.config.jurisdiction) {
+        if (overrides?.endpoint) {
+            this.endpoint = overrides.endpoint
+        } else if (this.config.jurisdiction) {
             this.endpoint = `https://${this.config.accountId}.${this.config.jurisdiction}.r2.cloudflarestorage.com`;
         } else {
             this.endpoint = `https://${this.config.accountId}.r2.cloudflarestorage.com`;
@@ -23,6 +25,7 @@ export class R2 {
                 secretAccessKey: this.config.secretAccessKey,
             },
             region: 'auto',
+            ...overrides
         });
     }
 


### PR DESCRIPTION
Adding this so development with [Localstack](https://docs.localstack.cloud/overview/) becomes possible.

This way, a custom endpoint can be provided (pointing to localhost) + other overrides to the S3 client if needed.